### PR TITLE
added duplicate tab action

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -122,6 +122,11 @@ browser.runtime.onMessage.addListener(
           browser.tabs.update(sender.tab.id, { muted: !currentMutedStatus });
         }
         break;
+      case Message.DUPLICATE_TAB:
+        if (sender.tab?.id) {
+          browser.tabs.duplicate(sender.tab.id);
+        }
+        break;
       case Message.OPEN_DOWNLOADS:
       case Message.OPEN_EXTENSION:
       case Message.OPEN_SETTINGS:

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -32,6 +32,7 @@ export const enum Message {
 
   TOGGLE_PIN_TAB = "toggle-pin-tab",
   TOGGLE_MUTE_TAB = "toggle-mute-tab",
+  DUPLICATE_TAB = "duplicate-tab",
 
   CHECK_SEARCH_OPEN = "check-search-open",
 

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -18,6 +18,7 @@ import { BiHistory } from "@react-icons/all-files/bi/BiHistory";
 import { BiVolumeMute } from "@react-icons/all-files/bi/BiVolumeMute";
 import { BiPin } from "@react-icons/all-files/bi/BiPin";
 import { BiStar } from "@react-icons/all-files/bi/BiStar";
+import { BiDuplicate } from "@react-icons/all-files/bi/BiDuplicate";
 
 export function getActions(): Action[] {
   return [
@@ -80,6 +81,11 @@ export function getActions(): Action[] {
       name: "Toggle Pin Tab",
       message: Message.TOGGLE_PIN_TAB,
       icon: BiPin,
+    },
+    {
+      name: "Duplicate Tab",
+      message: Message.DUPLICATE_TAB,
+      icon: BiDuplicate,
     },
 
     {


### PR DESCRIPTION
# Description

Added duplicate tab action. 

Closes #35

## Type of changes made

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# What changes were made

Method duplicate was used in order to duplicate current tab. Second optional parameter of the method was not used because it is [supported only in firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate#browser_compatibility)
