### PR TITLE
Set up listeners for tab updated and creation

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -4,13 +4,12 @@ import {
   Commands,
   Message,
   MessagePlayload,
-  UpdatedTabDataMessagePayload,
 } from "../common/types";
 import {
   getCurrentTab,
   getTabsInCurrentWindow,
-  getTabsWithSearchOpen,
   injectExtension,
+  reactOnTabUpdate
 } from "./utils";
 import browser from "webextension-polyfill";
 
@@ -53,31 +52,15 @@ browser.commands.onCommand.addListener((command) => {
 });
 
 // SHOULD ONLY SEND UPDATED TAB DATA IF A TAB IN THE SAME WINDOW AS THE OPEN SEARCH IS CLOSED
-browser.tabs.onRemoved.addListener(() => {
-  // should I make these async?
-  // send updated tab data if a tab is closed
-  // does not like async await
-  // if we are doing browser wide search, need to hadle changes in other windows
-  // the idea is just to send all open tab search modals an update
-  // if (!removedTabInfo.isWindowClosing) { // what happens if an entire window is closing
-  // essentially try and see if there is an active tab in that window with the search open and in tab search mode
-  // if there is, send the tab the updated tab data
-  getTabsWithSearchOpen().then((tabIds) => {
-    console.log(tabIds);
-    // for each active tab with their search open, send an update tto them
-    tabIds.forEach((id) => {
-      getTabsInCurrentWindow().then((updatedTabData) => {
-        const messagePayload: UpdatedTabDataMessagePayload = {
-          message: Message.TAB_DATA_UPDATE,
-          updatedTabData,
-        };
-        console.log("sending message");
-        browser.tabs.sendMessage(id, messagePayload);
-      });
-    });
-  });
-  // }
-});
+
+browser.tabs.onRemoved.addListener(reactOnTabUpdate);
+browser.tabs.onCreated.addListener(reactOnTabUpdate);
+browser.tabs.onUpdated.addListener((_, changeInfo, tab) => {
+  // wait for the tab to complete its update?
+  if (tab.status === "complete" && changeInfo.url) { // would url changes also incluse favicon changes?
+    reactOnTabUpdate();
+  }
+})
 
 browser.runtime.onMessage.addListener(
   (messagePayload: MessagePlayload, sender) => {

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -19,7 +19,7 @@ export async function getTabsWithSearchOpen(): Promise<number[]> {
   // get the tab in the window with search modal open and in tab search mode
   // in development, if the there are multiple windows and one of the active tabs in those windows has an isolated content script,
   // it will cause an error
-  const activeTabs = await browser.tabs.query({ active: true });
+  const activeTabs = await browser.tabs.query({ active: true, status: "complete" }); // can only communicate with tabs that are completely loaded
   console.log(activeTabs);
   const activeTabsLength = activeTabs.length;
   const result: number[] = [];
@@ -46,7 +46,7 @@ export async function getTabsWithSearchOpen(): Promise<number[]> {
   return result;
 }
 
-export async function getTabsInCurrentWindow() {
+export async function getTabsInBrowser() {
   // should it return the current tab??
   // should we be using the lastFocused?
   const tabs = await browser.tabs.query({});
@@ -149,7 +149,7 @@ export const reactOnTabUpdate = () => {
     console.log(tabIds);
     // for each active tab with their search open, send an update to them
     tabIds.forEach((id) => {
-      getTabsInCurrentWindow().then((updatedTabData) => {
+      getTabsInBrowser().then((updatedTabData) => {
         const messagePayload: UpdatedTabDataMessagePayload = {
           message: Message.TAB_DATA_UPDATE,
           updatedTabData,

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -4,11 +4,12 @@ import {
   Message,
   SearchMode,
   TabData,
+  UpdatedTabDataMessagePayload,
 } from "../common/types";
 import browser from "webextension-polyfill";
 
 export async function getCurrentTab() {
-  const [tab] = await browser.tabs.query({ active: true, currentWindow: true }); // what is the difference between currentWindow and lastFocused?
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
   return tab;
 }
 
@@ -141,3 +142,22 @@ export async function injectExtension() {
   //   }
   // }
 }
+
+export const reactOnTabUpdate = () => {
+  // send updated tab data to all open search modals in the browser
+  getTabsWithSearchOpen().then((tabIds) => {
+    console.log(tabIds);
+    // for each active tab with their search open, send an update to them
+    tabIds.forEach((id) => {
+      getTabsInCurrentWindow().then((updatedTabData) => {
+        const messagePayload: UpdatedTabDataMessagePayload = {
+          message: Message.TAB_DATA_UPDATE,
+          updatedTabData,
+        };
+        console.log("sending message");
+        browser.tabs.sendMessage(id, messagePayload);
+      });
+    });
+  });
+  // }
+};

--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -8,6 +8,7 @@ import { AiFillGoogleCircle } from "@react-icons/all-files/ai/AiFillGoogleCircle
 import { AiFillTwitterCircle } from "@react-icons/all-files/ai/AiFillTwitterCircle";
 import { AiFillYoutube } from "@react-icons/all-files/ai/AiFillYoutube";
 import { AiFillFacebook } from "@react-icons/all-files/ai/AiFillFacebook";
+import { AiFillPushpin } from "@react-icons/all-files/ai/AiFillPushpin";
 
 import { BiWindowClose } from "@react-icons/all-files/bi/BiWindowClose";
 import { BiWindowOpen } from "@react-icons/all-files/bi/BiWindowOpen";
@@ -72,15 +73,18 @@ export function getActions(): Action[] {
       message: Message.OPEN_BOOKMARKS,
       icon: BiStar,
     },
+    // this action will be removed
     {
       name: "Toggle Mute Tab",
       message: Message.TOGGLE_MUTE_TAB,
       icon: BiVolumeMute,
     },
+
+    // this action will be removed
     {
       name: "Toggle Pin Tab",
       message: Message.TOGGLE_PIN_TAB,
-      icon: BiPin,
+      icon: AiFillPushpin,
     },
     {
       name: "Duplicate Tab",

--- a/src/content/components/Search.tsx
+++ b/src/content/components/Search.tsx
@@ -386,9 +386,10 @@ export const Search = (props: Props) => {
             letter-spacing: normal !important;
 
             /* think about these */
-            /* -webkit-font-smoothing: antialiased;
+            /* things look slightly better with these selectors set */
+            -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
-            text-rendering: optimizeLegibility; */
+            text-rendering: optimizeLegibility;
           }
 
           /* disable scrollbar for virtualized list */


### PR DESCRIPTION
# Description

Set up listeners for tab updated and creation so it is reflected in the Search modal

Closes #14 

## Type of changes made

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# What changes were made
These changes were made so that when the Search modal is in Tab Search Mode, the modal is always in sync with the tabs in the browser.
