### PR TITLE
New injection strategy

### DIFF
--- a/src/content/components/Search.tsx
+++ b/src/content/components/Search.tsx
@@ -307,13 +307,13 @@ export const Search = (props: Props) => {
     // completely clearing the array in the long run might be safer than leaving the stale and incorrect data in state
     // and would also reduce us having to use another state value in the component
     // it would also simplify the some of the code in the currentSearchMode useEffect and in the fetchTabData method.
-    // if (isLoading) {
-    //   return (
-    //     <Empty>
-    //       <Heading>Loading...</Heading>
-    //     </Empty>
-    //   );
-    // }
+    if (isLoading) {
+      return (
+        <Empty>
+          <Heading>Loading...</Heading>
+        </Empty>
+      );
+    }
     if (filteredData.length === 0) {
       return (
         <Empty>

--- a/src/content/content.css
+++ b/src/content/content.css
@@ -17,8 +17,8 @@ tab-butler-modal {
   background-color: rgba(0, 0, 0, 0.5);
   /* background-color: transparent; */
   animation: fadeOut 0.5s;
-  opacity: 0;
-  visibility: hidden;
+  /* opacity: 0; */
+  /* visibility: hidden; */
   z-index: 999999 !important;
 }
 

--- a/src/content/content.css
+++ b/src/content/content.css
@@ -16,22 +16,5 @@ tab-butler-modal {
   /* think about this */
   background-color: rgba(0, 0, 0, 0.5);
   /* background-color: transparent; */
-  animation: fadeOut 0.5s;
-  /* opacity: 0; */
-  /* visibility: hidden; */
   z-index: 999999 !important;
-}
-
-.tab_butler_modal_visible {
-  visibility: visible;
-  opacity: 1;
-  /* animation: fadeIn 0.5s; */
-}
-
-.tab_butler_fade_in {
-  animation: fadeIn 0.5s;
-}
-
-.tab_butler_fade_out {
-  animation: fadeOut 0.5s;
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -14,13 +14,17 @@ const existingTabButlerModalRoot = document.querySelector("tab-butler-modal");
 if (existingTabButlerModalRoot) {
   existingTabButlerModalRoot.remove();
 }
+
+// by only creating and appending the element, dynamically when it is requested, it should save on memory and reduce some parts of the code
+// like the visibility toggeling and the style tag removal in the root
+// this should also help in sites where the dom might change from time to time, invalidating
 let tabButlerModalRoot: HTMLElement | null = null;
 // needs to be open so that the click event can bubble up
 let shadow: ShadowRoot | null = null;
 let isOpen = false; // technically no longer needed
 let currentSearchMode: SearchMode;
 const searchUiHandler = new SearchUIHandler();
-// make this file into a class that will be easier to manage?
+
 const messageListener = (messagePayload: MessagePlayload) => {
   // i will need to rename the component from search to something else
   const { message } = messagePayload;
@@ -52,7 +56,6 @@ function mountSearchComponent(message: Message) {
     searchMode: requestedSearchMode,
     close: unmountSearchComponent,
   });
-  // tabButlerModalRoot.classList.toggle("tab_butler_modal_visible");
   currentSearchMode = requestedSearchMode;
   isOpen = true;
   document.body.appendChild(tabButlerModalRoot);
@@ -78,16 +81,9 @@ function unmountSearchComponentFromMessage(message: Message) {
 }
 
 function unmountSearchComponent() {
-  // doing this first here so it disapears as soon as possible
-  // tabButlerModalRoot?.classList.toggle("tab_butler_modal_visible");
   document.removeEventListener("click", unmountOnClick);
   searchUiHandler.unMount();
-  // clear the remaining styles in the shadow root
   tabButlerModalRoot?.remove();
-  // while (shadow.firstChild) {
-  //   shadow.removeChild(shadow.firstChild);
-  // }
-
   isOpen = false;
   // should i reset currentSearchMode?
 }
@@ -107,5 +103,3 @@ window.addEventListener("beforeunload", () => {
     unmountSearchComponent();
   }
 });
-
-// document.body.appendChild(tabButlerModalRoot); // is there a possibility that document.body is null?

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -15,7 +15,7 @@ if (existingTabButlerModalRoot) {
   existingTabButlerModalRoot.remove();
 }
 
-// by only creating and appending the element, dynamically when it is requested, it should save on memory and reduce some parts of the code
+// by only creating and appending the element dynamically when it is requested, it should save on memory and reduce some parts of the code
 // like the visibility toggeling and the style tag removal in the root
 // this should also help in sites where the dom might change from time to time, invalidating
 let tabButlerModalRoot: HTMLElement | null = null;
@@ -46,6 +46,7 @@ const messageListener = (messagePayload: MessagePlayload) => {
 browser.runtime.onMessage.addListener(messageListener);
 
 function mountSearchComponent(message: Message) {
+  // create a new modal root on mount and append as the last child of the body
   tabButlerModalRoot = document.createElement("tab-butler-modal");
 // needs to be open so that the click event can bubble up
   shadow = tabButlerModalRoot.attachShadow({ mode: "open" });
@@ -84,6 +85,8 @@ function unmountSearchComponent() {
   document.removeEventListener("click", unmountOnClick);
   searchUiHandler.unMount();
   tabButlerModalRoot?.remove();
+  tabButlerModalRoot = null;
+  shadow = null;
   isOpen = false;
   // should i reset currentSearchMode?
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -14,9 +14,9 @@ const existingTabButlerModalRoot = document.querySelector("tab-butler-modal");
 if (existingTabButlerModalRoot) {
   existingTabButlerModalRoot.remove();
 }
-const tabButlerModalRoot = document.createElement("tab-butler-modal");
+let tabButlerModalRoot: HTMLElement | null = null;
 // needs to be open so that the click event can bubble up
-const shadow = tabButlerModalRoot.attachShadow({ mode: "open" });
+let shadow: ShadowRoot | null = null;
 let isOpen = false; // technically no longer needed
 let currentSearchMode: SearchMode;
 const searchUiHandler = new SearchUIHandler();
@@ -31,6 +31,7 @@ const messageListener = (messagePayload: MessagePlayload) => {
         // special function to switch modes if the message is different
         unmountSearchComponentFromMessage(message);
       } else {
+        console.log("here")
         mountSearchComponent(message);
       }
       break;
@@ -41,6 +42,9 @@ const messageListener = (messagePayload: MessagePlayload) => {
 browser.runtime.onMessage.addListener(messageListener);
 
 function mountSearchComponent(message: Message) {
+  tabButlerModalRoot = document.createElement("tab-butler-modal");
+// needs to be open so that the click event can bubble up
+  shadow = tabButlerModalRoot.attachShadow({ mode: "open" });
   const requestedSearchMode = getSearchModeFromMessage(message);
   document.addEventListener("click", unmountOnClick);
   searchUiHandler.mount(shadow, {
@@ -48,9 +52,10 @@ function mountSearchComponent(message: Message) {
     searchMode: requestedSearchMode,
     close: unmountSearchComponent,
   });
-  tabButlerModalRoot.classList.toggle("tab_butler_modal_visible");
+  // tabButlerModalRoot.classList.toggle("tab_butler_modal_visible");
   currentSearchMode = requestedSearchMode;
   isOpen = true;
+  document.body.appendChild(tabButlerModalRoot);
 }
 
 function unmountSearchComponentFromMessage(message: Message) {
@@ -74,13 +79,15 @@ function unmountSearchComponentFromMessage(message: Message) {
 
 function unmountSearchComponent() {
   // doing this first here so it disapears as soon as possible
-  tabButlerModalRoot.classList.toggle("tab_butler_modal_visible");
+  // tabButlerModalRoot?.classList.toggle("tab_butler_modal_visible");
   document.removeEventListener("click", unmountOnClick);
   searchUiHandler.unMount();
   // clear the remaining styles in the shadow root
-  while (shadow.firstChild) {
-    shadow.removeChild(shadow.firstChild);
-  }
+  tabButlerModalRoot?.remove();
+  // while (shadow.firstChild) {
+  //   shadow.removeChild(shadow.firstChild);
+  // }
+
   isOpen = false;
   // should i reset currentSearchMode?
 }
@@ -101,4 +108,4 @@ window.addEventListener("beforeunload", () => {
   }
 });
 
-document.body.appendChild(tabButlerModalRoot); // is there a possibility that document.body is null?
+// document.body.appendChild(tabButlerModalRoot); // is there a possibility that document.body is null?


### PR DESCRIPTION
# Description

The purpose of this change is to change how the Search modal is shown is injected into the webpage. Previously, the `tab-butler-modal` element was created and appended to the body when the content script is first executed and is reused when it is triggered again by the. This proved problematic for sites where their DOM structure would change too much and affect how the modal was shown (if it shows at all). Another problem with this old strategy is that the `tab-butler-modal` element would be created even if you never triggered the modal, which consumes memory.

## Type of changes made

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
This is more of a refactoring effort than anything else.


# What changes were made
With this new strategy, the `tab-butler-modal` element is dynamically created and appended to the body only when triggered and is disposed of when closed, consuming less memory in the long run. It also makes sure that every time it is injected into a site with a lot of DOM changes, the modal will always be inserted as the last child of the body, ensuring that the modal will render correctly every time.
